### PR TITLE
Improve CLI usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Examples:
 ### Basic Regex searching in the `.github/`
 
 ```sh
-cargo run -- -r Rust -p ./.github
+drgrep -r Rust -p ./.github
 ```
 
 Output: ![image](./assets/Capture%20d’écran%20du%202025-04-17%2020-40-36.png)

--- a/src/args/parser.rs
+++ b/src/args/parser.rs
@@ -61,6 +61,10 @@ impl ArgParser {
     pub fn has(&self, key: &str) -> bool {
         self.args.contains_key(key)
     }
+
+    pub fn set(&mut self, key: &str, val: String) {
+        self.args.insert(key.to_string(), Some(val));
+    }
 }
 
 impl Default for ArgParser  {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,14 @@ impl<'a> Config<'a> {
         };
         let search_content = match args.get("content") {
             Some(c) => Some(c.as_str()),
-            None => args.get("c").as_ref().map(|v| v.as_str()),
+            None => {
+                if let Some(c) = args.get("c") {
+                    Some(c.as_str())
+                } else {
+                    is_dir = true;
+                    None
+                }
+            }
         };
         // println!("search content in args: {}", search_content.unwrap());
         let sensitive = match args.get("sensitive") {
@@ -203,14 +210,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                         format!("source: {}", result.source).as_str(),
                         color::config::Color::BRIGHT_BLUE
                     );
-                    println!();
                     print_colored!(
                         format!("line: {}", result.idx).as_str(),
                         color::config::Color::RED
                     );
-                    println!();
                     print_partial_colored!(&result.line);
-                    println!("===========================");
+                    println!("=================================\n");
                 }
                 return Ok(());
             } else if config.sensitive {
@@ -220,14 +225,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                             format!("source: {}", result.source).as_str(),
                             color::config::Color::BRIGHT_BLUE
                         );
-                        println!();
                         print_colored!(
                             format!("line: {}", result.idx).as_str(),
                             color::config::Color::RED
                         );
-                        println!();
                         print_partial_colored!(&result.line);
-                        println!("===========================");
+                        println!("=================================\n");
                     }
                 }
                 return Ok(());
@@ -237,14 +240,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                         format!("source: {}", result.source).as_str(),
                         color::config::Color::BRIGHT_BLUE
                     );
-                    println!();
                     print_colored!(
                         format!("line: {}", result.idx).as_str(),
                         color::config::Color::RED
                     );
-                    println!();
                     print_partial_colored!(&result.line);
-                    println!("===========================");
+                    println!("=================================\n");
                 }
             }
             return Ok(());
@@ -257,9 +258,8 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                             format!("line: {}", result.idx).as_str(),
                             color::config::Color::RED
                         );
-                        println!();
                         print_partial_colored!(&result.line);
-                        println!("===========================");
+                        println!("=================================\n");
                     }
                 } else {
                     for result in search_word_insensitive_case(key, "", content) {
@@ -267,21 +267,18 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                             format!("line: {}", result.idx).as_str(),
                             color::config::Color::RED
                         );
-                        println!();
                         print_partial_colored!(&result.line);
-                        println!("===========================");
+                        println!("=================================\n");
                     }
                 }
             } else if let Some(reg) = config.regex {
                 for result in search_with_regex(&reg, "", content) {
-                    println!();
                     print_colored!(
                         format!("line: {}", result.idx).as_str(),
                         color::config::Color::RED
                     );
-                    println!();
                     print_partial_colored!(&result.line);
-                    println!("===========================");
+                    println!("=================================\n");
                 }
             }
         }
@@ -317,14 +314,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                                             format!("source: {}", result.source).as_str(),
                                             color::config::Color::BRIGHT_BLUE
                                         );
-                                        println!();
                                         print_colored!(
                                             format!("line: {}", result.idx).as_str(),
                                             color::config::Color::RED
                                         );
-                                        println!();
                                         print_partial_colored!(&result.line);
-                                        println!("===========================");
+                                        println!("=================================\n");
                                     }
                                     return;
                                 }
@@ -339,14 +334,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                                                 format!("source: {}", result.source).as_str(),
                                                 color::config::Color::BRIGHT_BLUE
                                             );
-                                            println!();
                                             print_colored!(
                                                 format!("line: {}", result.idx).as_str(),
                                                 color::config::Color::RED
                                             );
-                                            println!();
                                             print_partial_colored!(&result.line);
-                                            println!("===========================");
+                                            println!("=================================\n");
                                         }
                                     }
                                 } else if let Some(key) = config.search_key {
@@ -359,14 +352,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
                                             format!("source: {}", result.source).as_str(),
                                             color::config::Color::BRIGHT_BLUE
                                         );
-                                        println!();
                                         print_colored!(
                                             format!("line: {}", result.idx).as_str(),
                                             color::config::Color::RED
                                         );
-                                        println!();
                                         print_partial_colored!(&result.line);
-                                        println!("===========================");
+                                        println!("=================================\n");
                                     }
                                 }
                             }
@@ -582,21 +573,6 @@ mod utilities {
         stdin().read_to_string(&mut buffer)?;
         Ok(buffer)
     }
-
-    // fn visit_dirs_recursive(dir: &Path, outputs: Rc<RefCell<Vec<String>>>) -> io::Result<()> {
-    //     if dir.is_dir() {
-    //         for entry in fs::read_dir(dir)? {
-    //             let entry = entry?;
-    //             let path = entry.path();
-    //             if path.is_dir() {
-    //                 visit_dirs_recursive(&path, Rc::clone(&outputs))?;
-    //             } else if let Some(s) = path.to_str() {
-    //                 outputs.borrow_mut().push(s.to_string());
-    //             }
-    //         }
-    //     }
-    //     Ok(())
-    // }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,8 @@ pub use regex::pattern::find;
 pub use regex::pattern::find_all;
 pub use regex::pattern::is_match;
 pub use regex::pattern::replace_all;
-use regex::pattern::RegexPattern;
+pub use regex::pattern::RegexPattern;
+pub use utilities::read_stdin;
 
 /// The config struct
 #[derive(Debug)]
@@ -74,14 +75,16 @@ pub struct SearchResult<'a, 'b> {
 pub static DEFAULT_MESSAGE: &str = "\
 drgrep is a CLI searching tool
 Usage:
-drgrep [args]
+drgrep --[args]/-[flag]
 
-[args]
--k key <optional:false> => The word that you want to search
--p path <optional:true>, <default: '/'> => The path of the file which you want to provide searching
--r regex <optional:true> => The regex expression to use for matching
--c content <optional:true> => The content in which the program will process can be provided as string
--s sensitive <optional:true> => Use this to setup a sensitive case config you can use it with the env variables via : [DRGREP_SENSITIVE_CASE]
+[flags]-[args]
+-h --help => Print this default help message
+-v --version => Print the current version of the drgrep software
+-k --key <optional:false> => The word that you want to search
+-p --path <optional:true>, <default: '/'> => The path of the file which you want to provide searching
+-r --regex <optional:true> => The regex expression to use for matching
+-c --content <optional:true> => The content in which the program will process can be provided as string
+-s --sensitive <optional:true> => Use this to setup a sensitive case config you can use it with the env variables via : [DRGREP_SENSITIVE_CASE]
 ";
 
 pub static VERSION: &str = "v0.3.2";
@@ -115,7 +118,6 @@ impl<'a> Config<'a> {
                     is_dir = true;
                     Some(value.as_str())
                 } else {
-                    is_dir = true;
                     None
                 }
             }
@@ -133,7 +135,6 @@ impl<'a> Config<'a> {
                         None
                     }
                 } else {
-                    is_dir = true;
                     None
                 }
             }
@@ -164,6 +165,7 @@ impl<'a> Config<'a> {
             Some(c) => Some(c.as_str()),
             None => args.get("c").as_ref().map(|v| v.as_str()),
         };
+        // println!("search content in args: {}", search_content.unwrap());
         let sensitive = match args.get("sensitive") {
             Some(_) => true,
             None => match args.get("s") {
@@ -247,6 +249,7 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
             }
             return Ok(());
         } else if let Some(content) = config.search_content {
+            // println!("search content {}", content);
             if let Some(key) = config.search_key {
                 if config.sensitive {
                     for result in search_word_sensitive_case(key, "", content) {
@@ -495,7 +498,7 @@ mod utilities {
         env,
         error::Error,
         fs::{self, DirEntry},
-        io::{self, Read},
+        io::{self, stdin, Read},
         path::PathBuf,
         rc::Rc,
     };
@@ -572,6 +575,12 @@ mod utilities {
             }
         }
         Ok(())
+    }
+
+    pub fn read_stdin() -> io::Result<String> {
+        let mut buffer = String::new();
+        stdin().read_to_string(&mut buffer)?;
+        Ok(buffer)
     }
 
     // fn visit_dirs_recursive(dir: &Path, outputs: Rc<RefCell<Vec<String>>>) -> io::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,46 @@
-use std::process::{exit};
+use std::process::exit;
 
-use drgrep::{
-    args::parser::ArgParser, run, Config, DEFAULT_MESSAGE,
-};
+use drgrep::{args::parser::ArgParser, run, Config, DEFAULT_MESSAGE};
 
 fn main() {
-    let args: &ArgParser = &Default::default();
+    let args: &mut ArgParser = &mut Default::default();
 
     if args.has("version") || args.has("v") {
         println!("{}", drgrep::VERSION);
         exit(0);
+    }
+
+    if args.has("help") || args.has("h") {
+        println!("{}", drgrep::DEFAULT_MESSAGE);
+        exit(0);
+    }
+
+    // Catching the stdin if the user is using pipe
+    if args.has("content") {
+        match args.get("content") {
+            Some(content) => {
+                if content.as_str() == "@" {
+                    if let Ok(stdin_content) = drgrep::read_stdin() {
+                        args.set("content", stdin_content);
+                    }
+                }
+            }
+            None => (),
+        }
+    }
+    if args.has("c") {
+        match args.get("c") {
+            Some(content) => {
+                // println!("content key {}", content);
+                if content.as_str() == "@" {
+                    if let Ok(stdin_content) = drgrep::read_stdin() {
+                        // println!("stdin content {}", stdin_content);
+                        args.set("c", stdin_content);
+                    }
+                }
+            }
+            None => (),
+        }
     }
 
     let config = Config::new(args).unwrap_or_else(|_: &str| {


### PR DESCRIPTION
## Summary

Improve CLI usability by adding support for piped input ("@" placeholder), help and version flags, refining argument handling, and enhancing output formatting

New Features:
- Support reading search content from stdin when the content flag is set to "@"
- Add --help/-h and --version/-v flags to display usage message and version

Enhancements:
- Re-export read_stdin in the library and add ArgParser.set to allow updating arguments at runtime
- Revise the default help message to include flags and consistent argument syntax
- Standardize result output separators to a uniform line of equal signs

Documentation:
- Update README example to use drgrep command instead of cargo run