### PR TITLE
fix: downgrade version to 0.2.2 in Cargo files and update release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "drgrep"
-version = "0.3.2"
+version = "0.2.2"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drgrep"
-version = "0.3.2"
+version = "0.2.2"
 edition = "2021"
 license-file = "LICENSE"
 description = "A Rust implementation of the grep software with more support and features for args, workspace scanning and CLI"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ drgrep -k error -p application.log
 drgrep -r \\w\\w\\w\\w\\w -p document.txt
 ```
 
+### Using pipe
+
+```sh
+docker images | drgrep -k postgres -c @ # Be sure to pass this to tell the program to read the standard output
+```
+
 And other advanced regex features...
 
 ## 🌱 Contributing

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# 📦 drgrep v0.3.2 – Release Date: 2025-05-15
+# 📦 drgrep v0.2.2 – Release Date: 2025-05-15
 
 ## 🚀 New Features
 
@@ -8,7 +8,6 @@
 - 🚀 **strong regex integration**: Moving to new [regex](https://crates.io/crates/regex) engine with all needed support and more performance!
   1. Add new struct for the regex support `RegexPattern`
   2. New utility functions
-- 🎯 **CLI replacement in matched occurrences**: All the matched files can now be replace with any expression using regex
 - 💯 **Version checker CLI**: Add command to check your installation and the current version of the program
 
 ## 🐛 Bug Fixes
@@ -37,15 +36,15 @@ This comes with a new feature that will make possible to replace all matched occ
 1. Remove the existing binary (if your installation is manual).
 2. Download the latest release from [GitHub Releases](https://github.com/DoniLite/drgrep/releases).
 3. Add the new executable to your bin and export the path.
-4. Run `drgrep --version` to confirm the update.
+4. Run `drgrep --version | drgrep -v` to confirm the update.
 
 > For more information about installation mode check the [README](https://github.com/DoniLite/drgrep#%EF%B8%8F-installation)
 
 ## 📚 Documentation
 
-- Get the documentation [here](https://github.com/DoniLite/drgrep#)
+- Get the documentation [on this page](https://github.com/DoniLite/drgrep#)
 - The [website](https://donilite.github.io/drgrep/) of the project
 
 ## 🙌 Acknowledgements
 
-- 👏 thanks to @DoniLite the main contributor to these release
+- 👏 thanks to [@DoniLite](https://github.com/DoniLite) the main contributor to these release

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,7 +36,7 @@ This comes with a new feature that will make possible to replace all matched occ
 1. Remove the existing binary (if your installation is manual).
 2. Download the latest release from [GitHub Releases](https://github.com/DoniLite/drgrep/releases).
 3. Add the new executable to your bin and export the path.
-4. Run `drgrep --version | drgrep -v` to confirm the update.
+4. Run `drgrep --version / drgrep -v` to confirm the update.
 
 > For more information about installation mode check the [README](https://github.com/DoniLite/drgrep#%EF%B8%8F-installation)
 
@@ -47,4 +47,4 @@ This comes with a new feature that will make possible to replace all matched occ
 
 ## 🙌 Acknowledgements
 
-- 👏 thanks to [@DoniLite](https://github.com/DoniLite) the main contributor to these release
+- 👏 thanks to [@DoniLite](https://github.com/DoniLite) the main contributor to this release


### PR DESCRIPTION
## Summary by Sourcery

Downgrade crate version to 0.2.2 and refresh release notes and README to match the change

Build:
- Set package version to 0.2.2 in Cargo.toml

Documentation:
- Adjust RELEASE_NOTES.md header, remove outdated feature bullet, update installation instructions and link texts, and refine contributor acknowledgement
- Add a new "Using pipe" example in README demonstrating piping input to drgrep